### PR TITLE
Cli arguments

### DIFF
--- a/src/ws-rs/Cargo.lock
+++ b/src/ws-rs/Cargo.lock
@@ -112,7 +112,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "465a6172cf69b960917811022d8f29bc0b7fa1398bc4f78b3c466673db1213b6"
 dependencies = [
  "quote",
- "syn",
+ "syn 1.0.109",
 ]
 
 [[package]]
@@ -245,7 +245,7 @@ dependencies = [
  "actix-router",
  "proc-macro2",
  "quote",
- "syn",
+ "syn 1.0.109",
 ]
 
 [[package]]
@@ -256,7 +256,7 @@ checksum = "6d44b8fee1ced9671ba043476deddef739dd0959bf77030b26b738cc591737a7"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn",
+ "syn 1.0.109",
 ]
 
 [[package]]
@@ -310,6 +310,55 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "94fb8275041c72129eb51b7d0322c29b8387a0386127718b096429201a5d6ece"
 dependencies = [
  "alloc-no-stdlib",
+]
+
+[[package]]
+name = "anstream"
+version = "0.3.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0ca84f3628370c59db74ee214b3263d58f9aadd9b4fe7e711fd87dc452b7f163"
+dependencies = [
+ "anstyle",
+ "anstyle-parse",
+ "anstyle-query",
+ "anstyle-wincon",
+ "colorchoice",
+ "is-terminal",
+ "utf8parse",
+]
+
+[[package]]
+name = "anstyle"
+version = "1.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "41ed9a86bf92ae6580e0a31281f65a1b1d867c0cc68d5346e2ae128dddfa6a7d"
+
+[[package]]
+name = "anstyle-parse"
+version = "0.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e765fd216e48e067936442276d1d57399e37bce53c264d6fefbe298080cb57ee"
+dependencies = [
+ "utf8parse",
+]
+
+[[package]]
+name = "anstyle-query"
+version = "1.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5ca11d4be1bab0c8bc8734a9aa7bf4ee8316d462a08c6ac5052f888fef5b494b"
+dependencies = [
+ "windows-sys 0.48.0",
+]
+
+[[package]]
+name = "anstyle-wincon"
+version = "1.0.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "180abfa45703aebe0093f79badacc01b8fd4ea2e35118747e5811127f926e188"
+dependencies = [
+ "anstyle",
+ "windows-sys 0.48.0",
 ]
 
 [[package]]
@@ -397,6 +446,54 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "baf1de4339761588bc0619e3cbc0120ee582ebb74b53b4efbf79117bd2da40fd"
 
 [[package]]
+name = "clap"
+version = "4.2.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "34d21f9bf1b425d2968943631ec91202fe5e837264063503708b83013f8fc938"
+dependencies = [
+ "clap_builder",
+ "clap_derive",
+ "once_cell",
+]
+
+[[package]]
+name = "clap_builder"
+version = "4.2.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "914c8c79fb560f238ef6429439a30023c862f7a28e688c58f7203f12b29970bd"
+dependencies = [
+ "anstream",
+ "anstyle",
+ "bitflags",
+ "clap_lex",
+ "strsim",
+]
+
+[[package]]
+name = "clap_derive"
+version = "4.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3f9644cd56d6b87dbe899ef8b053e331c0637664e9e21a33dfcdc36093f5c5c4"
+dependencies = [
+ "heck",
+ "proc-macro2",
+ "quote",
+ "syn 2.0.15",
+]
+
+[[package]]
+name = "clap_lex"
+version = "0.4.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8a2dd5a6fe8c6e3502f568a6353e5273bbb15193ad9a89e457b9970798efbea1"
+
+[[package]]
+name = "colorchoice"
+version = "1.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "acbf1af155f9b9ef647e42cdc158db4b64a1b61f743629225fde6f3e0be2a7c7"
+
+[[package]]
 name = "convert_case"
 version = "0.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -470,7 +567,7 @@ dependencies = [
  "proc-macro2",
  "quote",
  "rustc_version",
- "syn",
+ "syn 1.0.109",
 ]
 
 [[package]]
@@ -626,6 +723,12 @@ name = "hashbrown"
 version = "0.12.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8a9ee70c43aaf417c914396645a0fa852624801b24ebb7ae78fe8272889ac888"
+
+[[package]]
+name = "heck"
+version = "0.4.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "95505c38b4572b2d910cecb0281560f54b440a19336cbbcb27bf6ce6adc6f5a8"
 
 [[package]]
 name = "hermit-abi"
@@ -1098,10 +1201,27 @@ dependencies = [
 ]
 
 [[package]]
+name = "strsim"
+version = "0.10.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "73473c0e59e6d5812c5dfe2a064a6444949f089e20eec9a2e5506596494e4623"
+
+[[package]]
 name = "syn"
 version = "1.0.109"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "72b64191b275b66ffe2469e8af2c1cfe3bafa67b529ead792a6d0160888b4237"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "unicode-ident",
+]
+
+[[package]]
+name = "syn"
+version = "2.0.15"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a34fcf3e8b60f57e6a14301a2e916d323af98b0ea63c599441eec8558660c822"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -1257,6 +1377,12 @@ dependencies = [
  "idna",
  "percent-encoding",
 ]
+
+[[package]]
+name = "utf8parse"
+version = "0.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "711b9620af191e0cdc7468a8d14e709c3dcdb115b36f838e601583af800a370a"
 
 [[package]]
 name = "version_check"
@@ -1441,6 +1567,7 @@ dependencies = [
  "actix-files",
  "actix-web",
  "actix-web-actors",
+ "clap",
  "env_logger",
  "log",
  "serde",

--- a/src/ws-rs/Cargo.toml
+++ b/src/ws-rs/Cargo.toml
@@ -14,3 +14,4 @@ env_logger = "0.10.0"
 log = "0.4.17"
 serde = "1.0.162"
 serde_json = "1.0.96"
+clap = { version = "4.2.7", features = ["derive"] }

--- a/src/ws-rs/src/cli.rs
+++ b/src/ws-rs/src/cli.rs
@@ -1,0 +1,45 @@
+use clap::Parser;
+
+#[derive(Debug, Parser)]
+#[command(author, version, about, long_about = None)] //TODO: fill values
+pub struct Args {
+    #[arg(
+        short = 'p',
+        long = "port",
+        help = "Local port to bind to (9090 if unset)"
+    )]
+    port: Option<u16>,
+    #[arg(
+        short = 'a',
+        long = "address",
+        help = "Address to bind to (binds on all addresses if unset)"
+    )]
+    address: Option<String>,
+    #[arg(long = "no-tls", help = "Don't use TLS")]
+    no_tls: bool,
+    #[arg(
+        long = "for-tls-proxy",
+        help = "Act behind a https-terminating proxy: accept only https:// origins by default"
+    )]
+    tls_proxy: Option<String>,
+    #[arg(long = "local-ssh", help = "Log in locally via SSH")]
+    ssh: bool,
+    #[arg(
+        long = "local-session",
+        help = "Launch a bridge in the local session (path to cockpit-bridge or '-' for stdin/out); implies --no-tls"
+    )]
+    session: bool,
+}
+
+impl Args {
+    pub fn get_port(&self) -> u16 {
+        self.port.unwrap_or(9090)
+    }
+
+    pub fn get_address(&self) -> String {
+        match self.address.clone() {
+            Some(address) => address,
+            None => String::from("0.0.0.0"),
+        }
+    }
+}

--- a/src/ws-rs/src/cockpit_branding.rs
+++ b/src/ws-rs/src/cockpit_branding.rs
@@ -1,4 +1,4 @@
-use std::path::Path;
+use std::path::{Path, PathBuf};
 
 use actix_files::NamedFile;
 use actix_web::{get, Error, HttpRequest, HttpResponse};
@@ -6,10 +6,10 @@ use std::{fs, io};
 
 use crate::state::WebCockpitState;
 
-fn find_file_from_roots(path: &str, roots: &Vec<String>) -> Result<NamedFile, Error> {
+fn find_file_from_roots(path: &str, roots: &Vec<PathBuf>) -> Result<NamedFile, Error> {
     // TODO: Handle root espace like (src/common/cockpitwebresponse.c:web_response_file)
     for root in roots {
-        let combined = format!("{root}/{path}");
+        let combined = root.join(path);
         let full_path = Path::new(&combined);
         if full_path.exists() {
             return NamedFile::open(full_path).map_err(|e| e.into());

--- a/src/ws-rs/src/constants.rs
+++ b/src/ws-rs/src/constants.rs
@@ -1,2 +1,5 @@
-// TODO: configure static path
+#[cfg(debug_assertions)]
 pub const STATIC_BASE_PATH: &str = "REPLACE_THIS_STRING!";
+
+#[cfg(not(debug_assertions))]
+pub const STATIC_BASE_PATH: &str = env!("DIST_PATH");

--- a/src/ws-rs/src/main.rs
+++ b/src/ws-rs/src/main.rs
@@ -1,4 +1,5 @@
 use std::fs;
+use std::path::PathBuf;
 
 use actix_web::{get, middleware, web, App, Error, HttpRequest, HttpResponse, HttpServer};
 use actix_web_actors::ws;
@@ -17,7 +18,7 @@ use self::constants::STATIC_BASE_PATH;
 
 #[get("/")]
 async fn index(data: WebCockpitState) -> Result<HttpResponse, Error> {
-    let html_base = fs::read_to_string(format!("{STATIC_BASE_PATH}login.html"))?;
+    let html_base = fs::read_to_string(PathBuf::from(STATIC_BASE_PATH).join("login.html"))?;
     let enviroment = data.build_js_environment();
     Ok(HttpResponse::Ok()
         .body(html_base.replace("<meta insert_dynamic_content_here>", &enviroment)))

--- a/src/ws-rs/src/state.rs
+++ b/src/ws-rs/src/state.rs
@@ -1,5 +1,9 @@
 use actix_web::web;
-use std::{collections::HashMap, fs, path::Path};
+use std::{
+    collections::HashMap,
+    fs,
+    path::{Path, PathBuf},
+};
 
 use crate::constants::STATIC_BASE_PATH;
 
@@ -29,8 +33,9 @@ fn gen_os_release() -> HashMap<String, String> {
     map
 }
 
-fn calculate_branding_roots(os_release: &HashMap<String, String>) -> Vec<String> {
-    let mut roots: Vec<String> = Vec::new();
+fn calculate_branding_roots(os_release: &HashMap<String, String>) -> Vec<PathBuf> {
+    let mut roots: Vec<PathBuf> = Vec::new();
+    let base = PathBuf::from(STATIC_BASE_PATH);
 
     // TODO: add_system_dirs from src/ws/cockpitbranding.c
 
@@ -55,21 +60,19 @@ fn calculate_branding_roots(os_release: &HashMap<String, String>) -> Vec<String>
     // This is for local testing
     if let Some(os_id) = os_release.get("ID") {
         if let Some(os_variant_id) = os_release.get("VARIANT_ID") {
-            roots.push(format!(
-                "{STATIC_BASE_PATH}branding/{os_id}-{os_variant_id}"
-            ));
+            roots.push(base.join(format!("branding/{os_id}-{os_variant_id}")));
         }
-        roots.push(format!("{STATIC_BASE_PATH}branding/{os_id}"));
+        roots.push(base.join(format!("branding/{os_id}")));
     }
 
     if let Some(os_id_like) = os_release.get("ID_LIKE") {
         for word in os_id_like.split(' ') {
-            roots.push(format!("{STATIC_BASE_PATH}branding/{word}"));
+            roots.push(base.join(format!("branding/{word}")));
         }
     }
 
-    roots.push(format!("{STATIC_BASE_PATH}branding/default"));
-    roots.push("{STATIC_BASE_PATH}".to_string());
+    roots.push(base.join("branding/default"));
+    roots.push(base);
     roots
 }
 
@@ -78,7 +81,7 @@ fn calculate_branding_roots(os_release: &HashMap<String, String>) -> Vec<String>
 pub struct CockpitState {
     // TODO: Auth
     os_release: HashMap<String, String>,
-    branding: Vec<String>,
+    branding: Vec<PathBuf>,
 }
 
 impl CockpitState {
@@ -91,7 +94,7 @@ impl CockpitState {
         }
     }
 
-    pub fn branding(&self) -> &Vec<String> {
+    pub fn branding(&self) -> &Vec<PathBuf> {
         &self.branding
     }
 

--- a/src/ws-rs/src/state.rs
+++ b/src/ws-rs/src/state.rs
@@ -16,17 +16,17 @@ fn gen_os_release() -> HashMap<String, String> {
 
     let content = fs::read_to_string(path).expect("Unexpected error reading os_release");
     for line in content.lines() {
-        if line.starts_with("#") {
+        if line.starts_with('#') {
             continue;
         }
 
-        let mut key_val = line.split("=");
+        let mut key_val = line.split('=');
         let key = key_val.next().unwrap();
         let value = key_val.next().unwrap().replace('"', "");
         map.insert(key.into(), value);
     }
 
-    return map;
+    map
 }
 
 fn calculate_branding_roots(os_release: &HashMap<String, String>) -> Vec<String> {
@@ -63,14 +63,14 @@ fn calculate_branding_roots(os_release: &HashMap<String, String>) -> Vec<String>
     }
 
     if let Some(os_id_like) = os_release.get("ID_LIKE") {
-        for word in os_id_like.split(" ") {
+        for word in os_id_like.split(' ') {
             roots.push(format!("{STATIC_BASE_PATH}branding/{word}"));
         }
     }
 
     roots.push(format!("{STATIC_BASE_PATH}branding/default"));
-    roots.push(format!("{STATIC_BASE_PATH}"));
-    return roots;
+    roots.push("{STATIC_BASE_PATH}".to_string());
+    roots
 }
 
 // CockpitHandlerData from src/ws/cockpithandlers.h


### PR DESCRIPTION
this adds a struct with all the cli arguments used by cockpit-ws, making it "technically" cli compatible although we do nothing with most of the args. I've also removed various useless format! using `.to_string` instead and moved all single chars from double quotes to single a single quotes specifies the char type and is better than using double quotes when addressing a single char. I've also removed return where it is not explicitly required. this brings clippy lints to 0